### PR TITLE
Add automatic site bootstrap in entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,17 @@ services:
       - mariadb
       - redis
     environment:
-      SITE_NAME: your-site-name
+      SITE_NAME: test_site
+      ADMIN_PWD: admin
+      DB_ROOT_PWD: ""
       DB_ROOT_USER: root
       MYSQL_ROOT_PASSWORD: root
       ADMIN_PASSWORD: admin
       INSTALL_APPS: erpnext,ferum_customs
+    volumes:
+      - sites_volume:/home/frappe/frappe-bench/sites
 
 volumes:
   mariadb:
   redis:
+  sites_volume:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,5 +13,17 @@ if [[ "$1" == "pytest" ]]; then
     shift
     bench --site "${SITE_NAME:-dev.localhost}" run-tests --app ferum_customs "$@"
 else
+    SITE_NAME=${SITE_NAME:-test_site}
+    ADMIN_PWD=${ADMIN_PWD:-admin}
+    DB_ROOT_PWD=${DB_ROOT_PWD:-""}  # empty string -> socket auth
+
+    if [ ! -f "/home/frappe/frappe-bench/sites/${SITE_NAME}/site_config.json" ]; then
+        echo ">> Creating Frappe site ${SITE_NAME}"
+        bench new-site "$SITE_NAME" \
+            --admin-password "$ADMIN_PWD" \
+            --mariadb-root-password "$DB_ROOT_PWD" \
+            --install-app erpnext
+    fi
+
     exec "$@"
 fi


### PR DESCRIPTION
## Summary
- create a Frappe site automatically in `entrypoint.sh`
- expose site settings in compose and mount sites directory

## Testing
- `pip install -r dev-requirements.txt` *(fails: dependency conflicts)*
- `pre-commit run --all-files` *(fails: `pre-commit` not installed)*
- `pytest` *(fails: `ModuleNotFoundError: No module named 'requests'`)*

------
https://chatgpt.com/codex/tasks/task_e_6847540bd7108328bb243ab82f094b70